### PR TITLE
Support for TLS configuration and per-host/group prospectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ filebeat_logstash_server: 'logstash.server.com'
 filebeat_logstash_server_port: 5044
 ```
 
+You can also define variable `filebeat_extra_prospectors` on a per-host or
+per-group basis.  This variable is concatenated with `filebeat_prospectors`
+when rendering the configuration template.
+
+
 ## Dependencies
 This role has no dependencies to other roles.
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,15 @@ Debian based Linux, tested on Ubuntu. Recent version of Ansible. Only utilized A
 # List of files to read logs from:
 filebeat_prospectors:
   - { paths: /var/log/*/*.log, input_type: log, document_type: log}
+
 # Logstash server to send logs to:
 filebeat_logstash_server: 'logstash.server.com'
 filebeat_logstash_server_port: 5044
+filebeat_logstash_tls: false
+filebeat_logstash_tls_certificate_authorities: []
+filebeat_logstash_tls_certificate:
+filebeat_logstash_tls_certificate_key:
+filebeat_logstash_tls_insecure: false
 ```
 
 You can also define variable `filebeat_extra_prospectors` on a per-host or

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,13 @@
 filebeat_logstash_server: localhost
 filebeat_logstash_server_port: 5044
 
+filebeat_logstash_tls: false
+filebeat_logstash_tls_certificate_authorities: []
+filebeat_logstash_tls_certificate:
+filebeat_logstash_tls_certificate_key:
+filebeat_logstash_tls_insecure: false
+
+
 # Example, overwrite this variable:
 filebeat_prospectors:
   -
@@ -39,3 +46,9 @@ filebeat_prospectors:
 # Set a custom one here if you want to apply differen message filters for different
 # log formats in logstash later/
 # The field `fields` just adds more metatdata to the message.
+
+
+# Extra prospectors - will be added to filebeat_prospectors list at runtime.
+# Facilitates having a base set of prospectors plus extra prospectors per host
+# or group.
+filebeat_extra_prospectors: []

--- a/templates/filebeat.yml.j2
+++ b/templates/filebeat.yml.j2
@@ -1,11 +1,19 @@
-################### Filebeat Configuration Example #########################
+# vim:ft=ansible:
+#===============================================================================
+#
+# Filebeat Configuration
+#
+#-------------------------------------------------------------------------------
+# {{ ansible_managed }}
+#===============================================================================
+
 
 ############################# Filebeat ######################################
 filebeat:
   # List of prospectors to fetch data.
   prospectors:
     # Each - is a prospector. Below are the prospector specific configurations
-{% for prospector in filebeat_prospectors %}
+{% for prospector in filebeat_all_prospectors %}
     -
       {{ prospector|to_nice_yaml|indent(6) }}
 
@@ -31,6 +39,7 @@ filebeat:
   # The config_dir MUST point to a different directory then where the main filebeat config file is in.
   #config_dir:
 
+
 ############################# Output ##########################################
 
 # Configure what outputs to use when sending the data collected by the beat.
@@ -53,28 +62,38 @@ output:
     # top topbeat and for Filebeat to filebeat.
     #index: filebeat
 
+{% if filebeat_logstash_tls %}
     # Optional TLS. By default is off.
-    #tls:
+    tls:
+      {% if filebeat_logstash_tls_certificate_authorities %}
       # List of root certificates for HTTPS server verifications
-      #certificate_authorities: ["/etc/pki/root/ca.pem"]
+      certificate_authorities: 
+        {{ filebeat_logstash_tls_certificate_authorities | to_nice_yaml | indent(8) }}
+      {% endif %}
 
+      {% if filebeat_logstash_tls_certificate %}
       # Certificate for TLS client authentication
-      #certificate: "/etc/pki/client/cert.pem"
+      certificate: {{ filebeat_logstash_tls_certificate }}
+      {% endif %}
 
+      {% if filebeat_logstash_tls_certificate_key %}
       # Client Certificate Key
-      #certificate_key: "/etc/pki/client/cert.key"
+      certificate_key: {{ filebeat_logstash_tls_certificate_key }}
+      {% endif %}
 
       # Controls whether the client verifies server certificates and host name.
       # If insecure is set to true, all server host names and certificates will be
       # accepted. In this mode TLS based connections are susceptible to
       # man-in-the-middle attacks. Use only for testing.
-      #insecure: true
+      insecure: {{ filebeat_logstash_tls_insecure }}
+
 
       # Configure cipher suites to be used for TLS connections
       #cipher_suites: []
 
       # Configure curve types for ECDHE based cipher suites
       #curve_types: []
+{% endif %}
 
 
   ### Console output

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
-# vars file for mediapeers.filebeat
+
+filebeat_all_prospectors: "{{ filebeat_prospectors + filebeat_extra_prospectors }}"


### PR DESCRIPTION
This PR adds support for configuring TLS, and for defining a `filebeat_extra_prospectors` variable on a per-host or per-group basis.  
